### PR TITLE
Decrease poll frequency of oxend SN info to 75% of the block target time

### DIFF
--- a/sent.py
+++ b/sent.py
@@ -681,7 +681,7 @@ def get_contribution_contracts():
     return app.contracts
 
 
-@timer(10)
+@timer(int(TARGET_BLOCK_TIME*3/4))
 def fetch_service_nodes(signum):
     app.logger.info("{} Update SN Start".format(date_now_str()))
     omq, oxend            = omq_connection()


### PR DESCRIPTION
Every 10s is currently overload the daemon because we are currently running the backend using UWSGI under multiple processes. So we don't have proper caching of responses, we can slow down how often we are polling since our block time is 2 minutes. There's no need to poll every 10s when it's not going to change for atleast 2 minutes.

This has been tested for awhile on the stagenet node with success, it's completely mitigated the daemon's job queue filling up with RPC requests and maxing itself out at 1k jobs.